### PR TITLE
Added missing method no_branch_lines to FileReporter

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -226,6 +226,9 @@ class FileReporter(coverage.plugin.FileReporter):
 
         return source_lines
 
+    def no_branch_lines(self):
+        return set()
+
 
 def running_sum(seq):
     total = 0

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -137,3 +137,15 @@ class StringTemplateTest(DjangoPluginTestCase):
             options={},
             )
         self.assertEqual(text, "Hello, World!")
+
+
+class BranchTest(DjangoPluginTestCase):
+
+    def test_with_branch_enabled(self):
+        self.make_template('Hello')
+        text = self.run_django_coverage(
+            options={'source': ["."], 'branch': True}
+            )
+        self.assertEqual(text, 'Hello')
+        self.assertEqual(self.get_line_data(), [-1, 1])
+        self.assertEqual(self.get_analysis(), ([1], []))


### PR DESCRIPTION
This solves the issue reported in: https://github.com/nedbat/django_coverage_plugin/issues/7