### PR TITLE
Fixed XML coverage (was missing file_locator)

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -6,6 +6,7 @@ import os.path
 from six.moves import range
 
 import coverage.plugin
+from coverage.files import FileLocator
 
 import django.template
 from django.template.base import (
@@ -136,10 +137,13 @@ class Plugin(coverage.plugin.CoveragePlugin, coverage.plugin.FileTracer):
 
 
 class FileReporter(coverage.plugin.FileReporter):
-    def __init__(self, filename):
+    def __init__(self, filename, file_locator=None):
+        self.file_locator = file_locator or FileLocator()
+
         # TODO: do we want the .filename attribute to be part of the public
         # API of the coverage plugin?
-        self.filename = filename
+        self.filename = self.file_locator.canonical_filename(filename)
+
         # TODO: is self.name required? Can the base class provide it somehow?
         self.name = os.path.relpath(filename)
         # TODO: html filenames are absolute.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -84,6 +84,8 @@ class CommentTest(DjangoPluginTestCase):
         self.assertEqual(text, "First\n\nLast\n")
         self.assertEqual(self.get_line_data(), [1, 2, 5])
         self.assertEqual(self.get_analysis(), ([1, 2, 5], []))
+        self.assertEqual(self.get_html_report(), 100)
+        self.assertEqual(self.get_xml_report(), 100)
 
     def test_with_stuff_inside(self):
         self.make_template("""\
@@ -99,6 +101,8 @@ class CommentTest(DjangoPluginTestCase):
         self.assertEqual(text, "First\n\nLast\n")
         self.assertEqual(self.get_line_data(), [1, 2, 7])
         self.assertEqual(self.get_analysis(), ([1, 2, 7], []))
+        self.assertEqual(self.get_html_report(), 100)
+        self.assertEqual(self.get_xml_report(), 100)
 
     def test_inline_comment(self):
         self.make_template("""\
@@ -110,6 +114,8 @@ class CommentTest(DjangoPluginTestCase):
         self.assertEqual(text, "First\n\nLast\n")
         self.assertEqual(self.get_line_data(), [1, 3])
         self.assertEqual(self.get_analysis(), ([1, 3], []))
+        self.assertEqual(self.get_html_report(), 100)
+        self.assertEqual(self.get_xml_report(), 100)
 
 
 class OtherTest(DjangoPluginTestCase):
@@ -126,6 +132,8 @@ class OtherTest(DjangoPluginTestCase):
         self.assertEqual(text, "First\n\n    look: 1 &lt; 2\n\nLast\n")
         self.assertEqual(self.get_line_data(), [1, 2, 3, 5])
         self.assertEqual(self.get_analysis(), ([1, 2, 3, 5], []))
+        self.assertEqual(self.get_html_report(), 100)
+        self.assertEqual(self.get_xml_report(), 100)
 
 
 class StringTemplateTest(DjangoPluginTestCase):
@@ -151,3 +159,5 @@ class BranchTest(DjangoPluginTestCase):
         self.assertEqual(text, 'Hello\nWorld\n\nGoodbye')
         self.assertEqual(self.get_line_data(), [1, 2, 3, 4])
         self.assertEqual(self.get_analysis(), ([1, 2, 3, 4], []))
+        self.assertEqual(self.get_html_report(), 100)
+        self.assertEqual(self.get_xml_report(), 100)


### PR DESCRIPTION
I don't expect you to accept this right off; I'm not sure I solved the problem in a way that meshes with your design vision. Is it ok to import coverage.files.FileLocator in the plugin, or should it only depend on coverage.plugin?

This does fix the issue detailed here:
https://github.com/nedbat/django_coverage_plugin/issues/9