### PR TITLE
Fixes to check_debug and adds support for Django 1.10 (the issues were heavily intertwined)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install: pip install tox-travis
+script: tox

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,3 +3,4 @@ contributions by:
 
 Jessamyn Smith
 Simon Charette
+Pamela McA'Nulty

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Checking settings configuration is deferred so that settings.py is included
 in coverage reporting.  Fixes `issue 28`_.
 
 Only the django.template.backends.django.DjangoTemplates template engine is
-supported, and it must be configured with ['OPTIONS']['debug'] = True.  Fixes
+supported, and it must be configured with ``['OPTIONS']['debug'] = True``.  Fixes
 `issue 27`_.
 
 .. _issue 28: https://github.com/nedbat/django_coverage_plugin/issues/28
@@ -160,7 +160,7 @@ To run the tests::
 .. |versions| image:: https://img.shields.io/pypi/pyversions/django_coverage_plugin.svg
     :target: https://pypi.python.org/pypi/django_coverage_plugin
     :alt: Python versions supported
-.. |djversions| image:: https://img.shields.io/badge/Django-1.4, 1.5, 1.6, 1.7, 1.8, 1.9-44b78b.svg
+.. |djversions| image:: https://img.shields.io/badge/Django-1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10
     :target: https://pypi.python.org/pypi/django_coverage_plugin
     :alt: Django versions supported
 .. |status| image:: https://img.shields.io/pypi/status/django_coverage_plugin.svg

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,9 @@ A `coverage.py`_ plugin to measure the coverage of Django templates.
 | |kit| |downloads|
 
 Supported Python versions are 2.7, 3.4, 3.5 and 3.6.
+
 Supported Django versions are 1.4 through 1.10.
+
 Supported coverage.py versions are 4.0 and higher.
 
 
@@ -66,7 +68,7 @@ Django 1.10.5 is now supported.
 Checking settings configuration is deferred so that settings.py is included
 in coverage reporting.  Fixes `issue 28`_.
 
-Only the django.template.backends.django.DjangoTemplates template engine is
+Only the ``django.template.backends.django.DjangoTemplates`` template engine is
 supported, and it must be configured with ``['OPTIONS']['debug'] = True``.  Fixes
 `issue 27`_.
 

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,10 @@ A `coverage.py`_ plugin to measure the coverage of Django templates.
 | |license| |versions| |djversions| |status|
 | |kit| |downloads|
 
-Supported Python versions are 2.7, 3.4, and 3.5.  Supported Django versions are
-1.4 through 1.9.
+Supported Python versions are 2.7, 3.4, 3.5 and 3.6.
+Supported Django versions are 1.4 through 1.10.
+Supported coverage.py versions are 4.0 and higher.
+
 
 The plugin is pip installable::
 
@@ -23,7 +25,7 @@ To run it, add this setting to your .coveragerc file::
     plugins =
         django_coverage_plugin
 
-Then run your tests under coverage.py. It requires coverage.py 4.0 or later.
+Then run your tests under coverage.py.
 
 You will see your templates listed in your coverage report along with your
 Python modules.
@@ -43,6 +45,8 @@ template files are included in the report.
 Caveats
 ~~~~~~~
 
+Support for Django versions 1.4 through 1.7 should be considered deprecated.
+
 Files included by the ``{% ssi %}`` tag are not included in the coverage
 measurements.
 
@@ -52,6 +56,22 @@ plural text, so both are marked as used if the tag is used.
 
 Changes
 ~~~~~~~
+
+
+v1.4 --- 2017-01-15
+---------------------
+
+Django 1.10.5 is now supported.
+
+Checking settings configuration is deferred so that settings.py is included
+in coverage reporting.  Fixes `issue 28`_.
+
+Only the django.template.backends.django.DjangoTemplates template engine is
+supported, and it must be configured with ['OPTIONS']['debug'] = True.  Fixes
+`issue 27`_.
+
+.. _issue 28: https://github.com/nedbat/django_coverage_plugin/issues/28
+.. _issue 27: https://github.com/nedbat/django_coverage_plugin/issues/27
 
 
 v1.3.1 --- 2016-06-02

--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -53,11 +53,16 @@ def check_debug():
         # Django 1.8+ handles both old and new-style settings and converts them
         # into template engines, so we don't need to depend on settings values
         # directly and can look at the resulting configured objects
+        if not hasattr(django.template.backends, "django"):
+            raise DjangoTemplatePluginException("Can't use non-Django templates.")
+
+        if not hasattr(django.template.backends.django, "DjangoTemplates"):
+            raise DjangoTemplatePluginException("Can't use non-Django templates.")
+
         for engine in django.template.engines.all():
             if not isinstance(engine, django.template.backends.django.DjangoTemplates):
                 raise DjangoTemplatePluginException(
-                    "Can't use non-Django templates. Found '%s': %s" %
-                    (engine.name, engine)
+                    "Can't use non-Django templates."
                 )
             if not engine.engine.debug:
                 raise DjangoTemplatePluginException(

--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -157,6 +157,8 @@ class DjangoTemplatePlugin(
     def file_tracer(self, filename):
         if filename.startswith(self.django_template_dir):
             if not self.debug_checked:
+                # Keep calling check_debug until it returns True, which it
+                # will only do after settings have been configured
                 self.debug_checked = check_debug()
 
             return self

--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -13,7 +13,6 @@ import coverage.plugin
 
 import django
 import django.template
-from django.core.exceptions import ImproperlyConfigured
 from django.template.base import (
     Lexer, TextNode, NodeList, Template,
     TOKEN_BLOCK, TOKEN_MAPPING, TOKEN_TEXT, TOKEN_VAR,
@@ -45,11 +44,6 @@ def check_debug():
 
     Returns True if the debug check was performed, False otherwise
     """
-    # The settings for templates changed in Django 1.8 from TEMPLATE_DEBUG to
-    # TEMPLATES[..]['debug'].  Django 1.9 tolerated both forms, 1.10 insists on
-    # the new form.  Don't try to be version-specific here.  If the new
-    # settings exist, use them, otherwise use the old.
-
     from django.conf import settings
 
     if not settings.configured:
@@ -58,7 +52,7 @@ def check_debug():
     if django.VERSION >= (1, 8):
         # Django 1.8+ handles both old and new-style settings and converts them
         # into template engines, so we don't need to depend on settings values
-        # directly
+        # directly and can look at the resulting configured objects
         for engine in django.template.engines.all():
             if not isinstance(engine, django.template.backends.django.DjangoTemplates):
                 raise DjangoTemplatePluginException(

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Software Development :: Quality Assurance

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ def index(request):
     """A bogus view to use in the urls below."""
     pass
 
+
 urlpatterns = [
     url(r'^home$', index, name='index'),
 ]

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -61,6 +61,7 @@ def test_settings():
 
     return the_settings
 
+
 settings.configure(**test_settings())
 
 if hasattr(django, "setup"):

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -67,10 +67,12 @@ settings.configure(**test_settings())
 if hasattr(django, "setup"):
     django.setup()
 
+from django.template import Context, Template  # noqa
+from django.template.loader import get_template  # noqa
+from django.test import TestCase  # noqa
 
-from django.template import Context, Template           # noqa
-from django.template.loader import get_template         # noqa
-from django.test import TestCase                        # noqa
+if django.VERSION >= (1, 8):
+    from django.template.backends.django import DjangoTemplates  # noqa
 
 
 class DjangoPluginTestCase(StdStreamCapturingMixin, TempDirMixin, TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ envlist =
     py27-django{14,15,16,17,18,19,110,110tip,tip},
     py34-django{15,16,17,18,19,110,110tip,tip},
     py35-django{18,19,110,110tip,tip},
+    py36-django{18,19,110,110tip,tip},
     check,doc
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@
 
 [tox]
 envlist =
-    py27-django{14,15,16,17,18,19,19tip,tip},
-    py34-django{15,16,17,18,19,19tip,tip},
-    py35-django{18,19,19tip,tip},
+    py27-django{14,15,16,17,18,19,110,110tip,tip},
+    py34-django{15,16,17,18,19,110,110tip,tip},
+    py35-django{18,19,110,110tip,tip},
     check,doc
 
 [testenv]
@@ -28,7 +28,8 @@ deps =
     django17: Django >=1.7, <1.8
     django18: Django >=1.8, <1.9
     django19: Django >=1.9, <1.10
-    django19tip: https://github.com/django/django/archive/stable/1.9.x.tar.gz
+    django110: Django >=1.10, <1.11
+    django110tip: https://github.com/django/django/archive/stable/1.10.x.tar.gz
     djangotip: https://github.com/django/django/archive/master.tar.gz
 
 commands =


### PR DESCRIPTION
Addresses a few issues:

 - https://github.com/nedbat/django_coverage_plugin/issues/26: Import `django.template.backends.django.DjangoTemplates` at top-level `plugin_test.py` to avoid it getting reloaded.
 - https://github.com/nedbat/django_coverage_plugin/issues/27: Reworking check_debug to walk list of template engines.
 - https://github.com/nedbat/django_coverage_plugin/issues/28 : Allow for coverage of settings while still calling check_debug
 - https://github.com/nedbat/django_coverage_plugin/issues/29: Potentially, since that was also diagnosed as caused by reading settings before they've been configured
 -  Fixed two `tox check` failures
 - Added support for travis-ci

Not sure how to test that settings.py gets coverage in the current environment.  I'm looking into creating a test_project that can be used for integration tests.


