### PR TITLE
Pm/insane integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ MANIFEST
 build
 dist
 integration_template_render
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ MANIFEST
 *.egg-info
 build
 dist
+integration_template_render

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -152,8 +152,9 @@ class IntegrationTest(DjangoPluginTestCase):
         # -- Add app to installed apps
         sep = ")" if django.VERSION < (1, 9) else "]"
         def _add_app(apps):
+            apps = list(apps)
             apps.append(app_name)
-            return apps
+            return tuple(apps)
         settings_data = change_elem(settings_data, "INSTALLED_APPS", sep, _add_app)
 
         def _update_templates_config(templates_config):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,16 +1,22 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/nedbat/django_coverage_plugin/blob/master/NOTICE.txt
 
-"""Settings tests for django_coverage_plugin."""
+"""
+    Full integration tests for django_coverage_plugin.
+    The tests in this module instantiate a minimal but complete
+    Django project and run tests against it.  This allows for
+    testing against various startup conditions since in other tests,
+    the django startup procedure is only executes once for each
+    python/django version combination.
+"""
 
 import os
-import subprocess
 import shutil
+import subprocess
 
 from .plugin_test import DjangoPluginTestCase
 
 import django
-
 
 VIEW_FUNC_TEXT = """
 def target_view(request):
@@ -20,6 +26,7 @@ def target_view(request):
         {"varA": 1212, "varB": "DcDc"},
     )
 """
+
 TEMPLATE_FILE_TEXT = """
 {% load test_tags %}
 
@@ -54,6 +61,7 @@ ignore_errors = True
 [combine]
 ignore_errors = True
 """
+
 TEST_VIEWS_FILE_TEXT = """
 import django
 from django.test import TestCase
@@ -87,18 +95,40 @@ def lower(value):
 
 
 def change_elem(data, elem_name, sep, func):
+    """
+    Find the configuration definition in `data`, evaluate
+    that defnition, pass the value to func, and convert the output
+    into the expected text format.
+
+    :param data:  Block of text
+    :param elem_name:  Name of element to be changed.  Must be defined
+    at the first column of the data text
+    :param sep:  separator to use in the definition
+    :param func: function to be called for transformation
+    :return: updated data text
+    """
     sep_open, sep_close = {"]": ("[", "]"), ")": ("(", ")")}[sep]
     before, after = data.split("%s = %s" % (elem_name, sep_open), 1)
+
+    # Find the end of the value definition, note that the closing
+    # separator must always be on its own line
     middle, after = after.split("\n%s\n" % sep_close, 1)
+
+    # Put the separators back
     elem = "%s%s%s" % (sep_open, middle, sep_close)
+
+    # Use eval to convert the text of value into a python data object
     elem = eval(elem)
 
+    # Call func to transform the python data object
     elem = func(elem)
 
+    # use pprint to convert the data to text and put it all back together
     import pprint
     middle = pprint.pformat(elem)
     middle = "%s\n%s\n" % (middle[:-1], sep)
-    return "%s%s = %s%s" % (before, elem_name, middle, after)
+    data = "%s%s = %s%s" % (before, elem_name, middle, after)
+    return data
 
 
 class IntegrationTest(DjangoPluginTestCase):
@@ -132,16 +162,16 @@ class IntegrationTest(DjangoPluginTestCase):
             fmt = "OS Error:\n  cmd: %s\n  exc: %s\ncwd: %s\n"
             raise Exception(fmt % (args, e, self.cwd))
 
-    def _pycmd(self, *args, **kwargs):
-        args = [self.python] + list(args)
-        return self._cmd(*args, **kwargs)
-
     def _cmd_global(self, *args, **kwargs):
+        """
+        Appends the env_bin path to the executable in arg[0]
+        Primarily used to run the `coverage` command
+        """
         args = list(args)
         args[0] = os.path.join(self.env_bin, args[0])
         return self._cmd(*args, **kwargs)
 
-    def _start_project(self, project_name):
+    def _start_project(self, project_name, debug=True):
         self.project_dir = os.path.join(os.getcwd(), project_name)
         if os.path.exists(self.project_dir):
             shutil.rmtree(self.project_dir)
@@ -149,16 +179,12 @@ class IntegrationTest(DjangoPluginTestCase):
         self.assertFalse(output)
         self.settings_file = os.path.join(self.project_dir, project_name, "settings.py")
         self._add_installed_app("django_coverage_plugin")
-        # self.addCleanup(shutil.rmtree, self.project_dir)
+        self._update_templates_config(debug=debug)
+        # Comment this line out to view the generated project files
+        self.addCleanup(shutil.rmtree, self.project_dir)
         return output
 
     def _add_installed_app(self, app_name):
-        with open(self.settings_file) as f:
-            settings_data = f.read()
-
-        # -- Add app to installed apps
-        sep = ")" if django.VERSION < (1, 9) else "]"
-
         def _add_app(apps):
             if django.VERSION < (1, 9):
                 apps = list(apps)
@@ -166,24 +192,27 @@ class IntegrationTest(DjangoPluginTestCase):
             if django.VERSION < (1, 9):
                 apps = tuple(apps)
             return apps
-        settings_data = change_elem(settings_data, "INSTALLED_APPS", sep, _add_app)
 
-        def _update_templates_config(templates_config):
+        with open(self.settings_file) as f:
+            settings_data = f.read()
+        sep = ")" if django.VERSION < (1, 9) else "]"
+        settings_data = change_elem(settings_data, "INSTALLED_APPS", sep, _add_app)
+        self._save_py_file(self.settings_file, settings_data)
+
+    def _update_templates_config(self, debug=True):
+        def _update_config(templates_config):
             if "APP_DIRS" in templates_config[0]:
                 del templates_config[0]['APP_DIRS']
-            templates_config[0]['OPTIONS']['debug'] = True
+            templates_config[0]['OPTIONS']['debug'] = debug
             templates_config[0]['OPTIONS']['loaders'] = (
                 'django.template.loaders.app_directories.Loader',
             )
             return templates_config
 
-        settings_data = change_elem(settings_data, "TEMPLATES", "]", _update_templates_config)
+        with open(self.settings_file) as f:
+            settings_data = f.read()
+        settings_data = change_elem(settings_data, "TEMPLATES", "]", _update_config)
         self._save_py_file(self.settings_file, settings_data)
-
-    def _print_file(self, file_data, file_name):
-        print("\n-------- begin: %s  --------" % file_name)
-        print(file_data)
-        print("-------- end: %s  --------\n\n" % file_name)
 
     def _save_py_file(self, path, data, show_data=False):
         with open(path, "w") as f:
@@ -201,8 +230,15 @@ class IntegrationTest(DjangoPluginTestCase):
     def _run_coverage(self, *args):
         self.set_cwd(self.project_dir)
         output = self._cmd_global("coverage", "run", "--rcfile", self.config_file, *args)
-        print(output)
-        self.assertNotIn("Disabling plugin", output)
+
+        if 0:
+            print("----- start output ----")
+            print(output)
+            print("------ end output ------")
+
+        if "Disabling plugin" in output:
+            return output, None
+
         env = os.environ.copy()
         env['DJANGO_SETTINGS_MODULE'] = self.settings_file
         coverage_report = self._cmd_global(
@@ -212,9 +248,9 @@ class IntegrationTest(DjangoPluginTestCase):
         coverage_report = self.parse_coverage_report(coverage_report)
         return output, coverage_report
 
-    def _create_django_project(self, project_name, app_name):
+    def _create_django_project(self, project_name, app_name, debug):
         self.cwd = os.getcwd()
-        self._start_project(project_name)
+        self._start_project(project_name, debug)
         self._start_app(app_name)
         self.config_file = self._add_project_file(COVERAGE_CFG_FILE_TEXT, "coverage.cfg")
         self.template_file = self._add_project_file(
@@ -228,12 +264,12 @@ class IntegrationTest(DjangoPluginTestCase):
             import_reverse = "from django.urls import reverse"
 
         test_views_text = TEST_VIEWS_FILE_TEXT % locals()
-        self.test_views_file = self._add_project_file(test_views_text, app_name, "test_views.py")
+        self._add_project_file(test_views_text, app_name, "test_views.py")
 
         self.views_file = os.path.join(self.project_dir, app_name, "views.py")
         self.urls_file = os.path.join(self.project_dir, project_name, "urls.py")
-        self.test_views_file = self._add_project_file("", app_name, "templatetags", "__init__.py")
-        self.test_views_file = self._add_project_file(
+        self._add_project_file("", app_name, "templatetags", "__init__.py")
+        self._add_project_file(
             TEMPLATE_TAG_TEXT, app_name, "templatetags", "test_tags.py"
         )
 
@@ -275,10 +311,66 @@ class IntegrationTest(DjangoPluginTestCase):
 
         self._save_py_file(self.urls_file, urls_data)
 
+    def test_no_debug(self):
+        self._create_django_project("integration_template_render", "app_template_render", debug=False,)
+        output, coverage_report = self._run_coverage("manage.py", "test", "app_template_render")
+        self.assertIn("Disabling plugin", output)
+        self.assertIn("Template debugging must be enabled in settings.", output)
+
+    def test_wrong_engine(self):
+        self._create_django_project("integration_template_render", "app_template_render", debug=True)
+        self._change_template_engine()
+        output, coverage_report = self._run_coverage("manage.py", "test", "app_template_render")
+        self.assertIn("Disabling plugin", output)
+        self.assertIn("Can't use non-Django templates.", output)
+
+    def _change_template_engine(self):
+        with open(self.settings_file) as f:
+            settings_data = f.read()
+        settings_data = settings_data.replace(
+            "django.template.backends.django.DjangoTemplates",
+            "integration_template_render.settings.FakeTemplateBackend",
+        )
+        settings_data = settings_data.replace(
+            "\nTEMPLATES = ",
+            """
+from django.template import TemplateDoesNotExist, TemplateSyntaxError
+from django.template.backends.base import BaseEngine
+from django.template.backends.utils import csrf_input_lazy, csrf_token_lazy
+
+class Template(object):
+    def __init__(self, template):
+        self.template = template
+    def render(self, context=None, request=None):
+        return "1212 DcDc LOWER: dcdc <title>Example: 1212</title>"
+class FakeTemplateBackend(BaseEngine):
+    app_dirname = 'fake'
+
+    def __init__(self, params):
+        params = params.copy()
+        params.pop('OPTIONS')
+        super(FakeTemplateBackend, self).__init__(params)
+
+    def from_string(self, template_code):
+        return Template(template_code)
+
+    def get_template(self, template_name):
+        return Template(template_name)
+
+TEMPLATES = """,
+        )
+        self._save_py_file(self.settings_file, settings_data)
+
     def test_template_render(self):
-        self._create_django_project("integration_template_render", "app_template_render")
+        self._create_django_project(
+            "integration_template_render",
+            "app_template_render",
+            debug=True,
+        )
 
         output, coverage_report = self._run_coverage("manage.py", "test", "app_template_render")
+
+        self.assertNotIn("Disabling plugin", output)
         self.assertIn("\nOK\n", output)
         self.assertIn("Ran 1 test", output)
         self.assertNotIn("ERROR", output)
@@ -289,15 +381,16 @@ class IntegrationTest(DjangoPluginTestCase):
         self.assertIsCovered(coverage_report, "integration_template_render/__init__.py")
         self.assertIsCovered(coverage_report, "integration_template_render/urls.py")
 
+        # Different versions of Django result in different coverage for manage.py
         if django.VERSION < (1, 10):
             expect_missing, expect_pct = 0, 100
         elif django.VERSION < (2, 0):
             expect_missing, expect_pct = 6, 54
         else:
-            # This is django-tip, so it's likely to change over time.
+            # This includes django-tip, so it's likely to change over time.
             expect_missing, expect_pct = 2, 78
-
         self.assertIsCovered(coverage_report, "manage.py", expect_missing, expect_pct)
+
         self.assertIsCovered(coverage_report, "app_template_render/__init__.py")
         self.assertIsCovered(coverage_report, "app_template_render/views.py")
         self.assertIsCovered(coverage_report, "app_template_render/templates/target_template.html")
@@ -343,7 +436,7 @@ class IntegrationTest(DjangoPluginTestCase):
                         continue
                     elif "-" in chunk:
                         start, end = chunk.split("-", 1)
-                        for i in range(int(start), int(end+1)):
+                        for i in range(int(start), int(end + 1)):
                             yield i
                     else:
                         yield int(chunk)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -430,11 +430,13 @@ TEMPLATES = """,
                 return fmt % (self.num_lines, self.num_missing, self.pct, self.missing)
 
             def missing_line_numbers(self):
+                # generate line numbers
                 for chunk in self.missing.split(","):
                     chunk = chunk.strip()
                     if not chunk:
                         continue
                     elif "-" in chunk:
+                        # This is a range, so generate the lineno for each line in the range
                         start, end = chunk.split("-", 1)
                         for i in range(int(start), int(end + 1)):
                             yield i

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -152,9 +152,12 @@ class IntegrationTest(DjangoPluginTestCase):
         # -- Add app to installed apps
         sep = ")" if django.VERSION < (1, 9) else "]"
         def _add_app(apps):
-            apps = list(apps)
+            if django.VERSION < (1, 9):
+                apps = list(apps)
             apps.append(app_name)
-            return tuple(apps)
+            if django.VERSION < (1, 9):
+                apps = tuple(apps)
+            return apps
         settings_data = change_elem(settings_data, "INSTALLED_APPS", sep, _add_app)
 
         def _update_templates_config(templates_config):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,380 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/nedbat/django_coverage_plugin/blob/master/NOTICE.txt
+
+"""Settings tests for django_coverage_plugin."""
+
+import os
+import subprocess
+import shutil
+
+from .plugin_test import DjangoPluginTestCase, django_start_at
+
+import django
+
+
+VIEW_FUNC_TEXT = """
+def target_view(request):
+    return render(
+        request,
+        "target_template.html",
+        {"varA": 1212, "varB": "DcDc"},
+    )
+"""
+TEMPLATE_FILE_TEXT = """
+{% load test_tags %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Example: {{ varA }}</title>
+</head>
+<body>
+{% if varA %}
+    {{ varA }}
+{% endif %}
+<br/>
+{% if varA %}
+    {{ varB }}
+{% endif %}
+LOWER: {{ varB|lower }}
+</body>
+</html>
+"""
+COVERAGE_CFG_FILE_TEXT = """
+[run]
+plugins =
+    django_coverage_plugin
+
+omit = .tox
+
+[report]
+ignore_errors = True
+
+[combine]
+ignore_errors = True
+"""
+TEST_VIEWS_FILE_TEXT = """
+import django
+from django.test import TestCase
+
+class TestViews(TestCase):
+   def test_view_target_view(self):
+        %(import_reverse)s
+
+        %(define_target_view)s
+
+        resp = self.client.get(reverse(target_view))
+        self.assertContains(resp, '1212')
+        self.assertContains(resp, 'DcDc')
+        self.assertContains(resp, 'LOWER: dcdc')
+        self.assertContains(resp, '<title>Example: 1212</title>')
+
+"""
+TEMPLATE_TAG_TEXT = """
+from django import template
+from django.utils.safestring import mark_safe
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+@register.filter(is_safe=True)
+@stringfilter
+def lower(value):
+    return mark_safe(value.lower())
+
+"""
+
+
+class IntegrationTest(DjangoPluginTestCase):
+    """Tests greenfield settings initializations and other weirdnesses"""
+
+    def setUp(self):
+        self.python = os.path.abspath(os.environ['_'])
+        if ".tox" in self.python:
+            self.env_bin = os.path.dirname(self.python)
+        else:
+            self.env_bin = ""
+            self.python = ""
+
+    def set_cwd(self, path):
+        self.cwd = path
+
+    def _cmd(self, *args, **kwargs):
+        try:
+            output = subprocess.check_output(args, cwd=self.cwd, stderr=subprocess.STDOUT, **kwargs)
+            return output.decode("utf-8").strip()
+        except subprocess.CalledProcessError as e:
+            fmt = "Called Processed Error:\n  cmd: %s\n  exc: %s\ncwd: %s\n  output:\n%s"
+            raise Exception(fmt % (args, e, self.cwd, e.output))
+        except OSError as e:
+            fmt = "OS Error:\n  cmd: %s\n  exc: %s\ncwd: %s\n"
+            raise Exception(fmt % (args, e, self.cwd))
+
+    def _pycmd(self, *args, **kwargs):
+        args = [self.python] + list(args)
+        return self._cmd(*args, **kwargs)
+
+    def _cmd_global(self, *args, **kwargs):
+        args = list(args)
+        args[0] = os.path.join(self.env_bin, args[0])
+        return self._cmd(*args, **kwargs)
+
+    def _start_project(self, project_name):
+        self.project_dir = os.path.join(os.getcwd(), project_name)
+        if os.path.exists(self.project_dir):
+            shutil.rmtree(self.project_dir)
+        output = self._cmd("django-admin.py", "startproject", project_name)
+        self.assertFalse(output)
+        self.settings_file = os.path.join(self.project_dir, project_name, "settings.py")
+        if django.VERSION < (1, 6):
+            with open(self.settings_file) as f:
+                data = f.read()
+            data = data.replace("'django.db.backends.'", "'django.db.backends.sqlite3'")
+            with open(self.settings_file, "w") as f:
+                f.write(data)
+
+        self._add_installed_app("django_coverage_plugin")
+        #self.addCleanup(shutil.rmtree, self.project_dir)
+        return output
+
+    def _add_installed_app(self, app_name):
+        with open(self.settings_file) as f:
+            settings_data = f.read()
+
+        sep_open, sep_close = ("(", ")") if django.VERSION < (1, 9) else ("[", "]")
+        try:
+            before, after = settings_data.split("INSTALLED_APPS = %s" % sep_open, 1)
+        except Exception:
+            self._print_file(settings_data, self.settings_file)
+            raise
+
+        apps, after = after.split(sep_close, 1)
+        apps = "%s\n    '%s',\n" % (apps, app_name)
+        settings_data = "%sINSTALLED_APPS = %s%s%s%s" % (before, sep_open, apps, sep_close, after)
+
+        if django.VERSION >= (1, 8):
+            before, after = settings_data.split("\nTEMPLATES =", 1)
+            middle, after = after.split("\n]", 1)
+            middle = "%s]" % middle
+
+            templates_config = eval(middle)
+            if "APP_DIRS" in templates_config[0]:
+                del templates_config[0]['APP_DIRS']
+            templates_config[0]['OPTIONS']['debug'] = True
+            templates_config[0]['OPTIONS']['loaders'] = ('django.template.loaders.app_directories.Loader',)
+
+            import pprint
+            middle = pprint.pformat(templates_config)
+            print middle
+
+            settings_data = "%s\nTEMPLATES = %s%s" % (before, middle, after)
+
+            if 0:
+                before, after = settings_data.split("OPTIONS': {", 1)
+                middle, after = after.split("}", 1)
+                if "'debug':True, " not in middle:
+                    middle = "            'debug':True,\n %s" % middle
+                if "loaders" not in middle:
+                    middle = "            'loaders': ('django.template.loaders.app_directories.Loader',),\n %s" % middle
+                settings_data = "%sOPTIONS': {%s}%s" % (before, middle, after)
+
+            self._save_py_file(self.settings_file, settings_data)
+
+    def _print_file(self, file_data, file_name):
+        print("\n-------- begin: %s  --------" % file_name)
+        print(file_data)
+        print("-------- end: %s  --------\n\n" % file_name)
+
+    def _save_py_file(self, path, data, show_data=False):
+        with open(path, "w") as f:
+            f.write(data)
+        pyc_path = "%sc" % path
+        if os.path.exists(pyc_path):
+            os.remove(pyc_path)
+
+    def _start_app(self, app_name):
+        self.set_cwd(self.project_dir)
+        output = self._cmd("./manage.py", "startapp", app_name)
+        self.assertFalse(output)
+        self._add_installed_app(app_name)
+
+    def _run_coverage(self, *args):
+        self.set_cwd(self.project_dir)
+        output = self._cmd_global("coverage", "run", "--rcfile", self.config_file, *args)
+        print(output)
+        self.assertNotIn("Disabling plugin", output)
+        env = os.environ.copy()
+        env['DJANGO_SETTINGS_MODULE'] = self.settings_file
+        coverage_report = self._cmd_global(
+            "coverage", "report", "-m", "--rcfile", self.config_file,
+            env=env
+        )
+        coverage_report = self.parse_coverage_report(coverage_report)
+        return output, coverage_report
+
+    def _create_django_project(self, project_name, app_name):
+        self.cwd = os.getcwd()
+        self._start_project(project_name)
+        self._start_app(app_name)
+        self.config_file = self._add_project_file(COVERAGE_CFG_FILE_TEXT, "coverage.cfg")
+        self.template_file = self._add_project_file(
+            TEMPLATE_FILE_TEXT, app_name, "templates", "target_template.html"
+        )
+
+        if django.VERSION < (1, 8):
+            define_target_view = '"app_template_render.views.target_view"'
+        else:
+            define_target_view = 'from app_template_render.views import target_view'
+        if django.VERSION < (1, 10):
+            import_reverse = "from django.core.urlresolvers import reverse"
+        else:
+            import_reverse = "from django.urls import reverse"
+
+        test_views_text = TEST_VIEWS_FILE_TEXT % locals()
+        self.test_views_file = self._add_project_file(test_views_text, app_name, "test_views.py")
+
+        self.views_file = os.path.join(self.project_dir, app_name, "views.py")
+        self.urls_file = os.path.join(self.project_dir, project_name, "urls.py")
+        self.test_views_file = self._add_project_file("", app_name, "templatetags", "__init__.py")
+        self.test_views_file = self._add_project_file(
+            TEMPLATE_TAG_TEXT, app_name, "templatetags", "test_tags.py"
+        )
+
+        self._add_view_function(app_name, VIEW_FUNC_TEXT)
+        self._add_url(project_name, app_name, "target_view", "target_view")
+
+    def _add_project_file(self, file_data, *path):
+        file_path = os.path.join(self.project_dir, *path)
+        try:
+            os.makedirs(os.path.dirname(file_path), )
+        except os.error:
+            pass
+
+        with open(file_path, "w") as f:
+            f.write(file_data)
+        return file_path
+
+    def _add_view_function(self, app_name, view_text):
+        with open(self.views_file) as f:
+            views_data = f.read()
+        views_data = "%s\n%s\n" % (views_data, view_text)
+        self._save_py_file(self.views_file, views_data)
+
+    def _add_url(self, project_name, app_name, view_func, view_name):
+        with open(self.urls_file) as f:
+            urls_data = f.read()
+
+        if django.VERSION < (1, 8):
+            before = "\n)\n"
+            fmt = "    url(r'^$', '%(app_name)s.views.target_view', name='target_view')\n)\n"
+            after = fmt % locals()
+            urls_data = urls_data.replace(before, after)
+
+        else:
+            urls_data = urls_data.replace(
+                "urlpatterns = [",
+                "import %s.views\n\nurlpatterns = [" % app_name
+            )
+            fmt = '''    url(r'^%(app_name)s/', %(app_name)s.views.%(view_func)s),\n]'''
+            urls_data = urls_data.replace("]", fmt % locals())
+
+        self._save_py_file(self.urls_file, urls_data)
+
+    @django_start_at(1, 8)
+    def test_template_render(self):
+        self._create_django_project("integration_template_render", "app_template_render")
+
+        output, coverage_report = self._run_coverage("manage.py", "test", "app_template_render")
+        self.assertIn("\nOK\n", output)
+        self.assertIn("Ran 1 test", output)
+        self.assertNotIn("ERROR", output)
+        self.assertNotIn("FAIL", output)
+
+        # import pprint;pprint.pprint(coverage_report)
+        self.assertIsCovered(coverage_report, "integration_template_render/settings.py")
+        self.assertIsCovered(coverage_report, "integration_template_render/__init__.py")
+        self.assertIsCovered(coverage_report, "integration_template_render/urls.py")
+
+        if django.VERSION < (1, 10):
+            expect_missing, expect_pct = 0, 100
+        elif django.VERSION < (2, 0):
+            expect_missing, expect_pct = 6, 54
+        else:
+            # This is django-tip, so it's likely to change over time.
+            expect_missing, expect_pct = 2, 78
+
+        self.assertIsCovered(coverage_report, "manage.py", expect_missing, expect_pct)
+        self.assertIsCovered(coverage_report, "app_template_render/__init__.py")
+        self.assertIsCovered(coverage_report, "app_template_render/views.py")
+        self.assertIsCovered(coverage_report, "app_template_render/templates/target_template.html")
+        self.assertIsCovered(coverage_report, "app_template_render/templatetags/test_tags.py")
+
+    def assertIsCovered(self, cov_report, path, expect_missing=0, expect_pct=100):
+        fmt = u"%s [%s] expected: %%r, got %%r"
+        info = cov_report[path]
+        fmt = fmt % (path, info)
+        if info.num_missing != expect_missing or info.pct != expect_pct:
+            missing_line_numbers = set(info.missing_line_numbers())
+            full_path = os.path.join(self.project_dir, path)
+            print("FILE:", full_path)
+            with open(full_path) as f:
+                for idx, line in enumerate(f):
+                    line_no = idx + 1
+                    status = "M" if line_no in missing_line_numbers else " "
+                    print("%s %4s  %s" % (status, line_no, line[:-1]))
+
+        self.assertEqual(info.num_missing, expect_missing, fmt % (expect_missing, info.num_missing))
+        self.assertEqual(info.pct, expect_pct, fmt % (expect_pct, info.pct))
+
+    def parse_coverage_report(self, report):
+        class ReportInfo(object):
+            def __init__(self, num_lines, num_missing, pct, missing):
+                self.num_lines = num_lines
+                self.num_missing = num_missing
+                self.pct = int(pct[:-1])
+                self.missing = missing
+
+            def __unicode__(self):
+                fmt = u"%s/%s/%s%%%%/%s"
+                return fmt % (self.num_lines, self.num_missing, self.pct, self.missing)
+
+            def __repr__(self):
+                fmt = u"ReportInfo(num_lines=%r, num_missing=%r, pct=%r, missing=%r)"
+                return fmt % (self.num_lines, self.num_missing, self.pct, self.missing)
+
+            def missing_line_numbers(self):
+                for chunk in self.missing.split(","):
+                    chunk = chunk.strip()
+                    if not chunk:
+                        continue
+                    elif "-" in chunk:
+                        start, end = chunk.split("-", 1)
+                        for i in range(int(start), int(end+1)):
+                            yield i
+                    else:
+                        yield int(chunk)
+
+        report_dict = {}
+        for line in report.splitlines():
+            if "/.tox/" in line:
+                continue
+            pieces = line.split(None, 4)
+            if len(pieces) not in (4, 5):
+                continue
+
+            if pieces[3][-1] != '%':
+                continue
+            if pieces[0] in ("Name", "TOTAL"):
+                continue
+
+            if len(pieces) == 4:
+                file, num_lines, num_missing, pct = pieces
+                missing = ""
+            elif len(pieces) == 5:
+                file, num_lines, num_missing, pct, missing = pieces
+            else:
+                continue
+
+            report_dict[file] = ReportInfo(int(num_lines), int(num_missing), pct, missing)
+        return report_dict

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -105,7 +105,13 @@ class IntegrationTest(DjangoPluginTestCase):
     """Tests greenfield settings initializations and other weirdnesses"""
 
     def setUp(self):
-        self.python = os.path.abspath(os.environ['_'])
+        self.python = ""
+
+        if '_' in os.environ:
+            self.python = os.path.abspath(os.environ['_'])
+        elif "VIRTUAL_ENV" in os.environ:
+            self.python = "%s/bin/python" % os.environ["VIRTUAL_ENV"]
+
         if ".tox" in self.python:
             self.env_bin = os.path.dirname(self.python)
         else:


### PR DESCRIPTION
NOT READY FOR REVIEW

Testing the complex and deferred initializations during django startup is pretty much impossible from within a standard unittest module.  This PR is a first draft to add a test that programmatically (using subprocess.check_output calls) creates a django project and runs its unittests under coverage and checks that coverage matches expectations.

I suspect I might refactor the common insane_integration test into a gist or even a pypi package so that other django-packages could use it