### PR TITLE
Fix DJ check_debug issue with DJ1.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,14 @@ plural text, so both are marked as used if the tag is used.
 Changes
 ~~~~~~~
 
+v1.4.2 --- 2017-01-30
+---------------------
+
+Fixes `issue 36`_, and another instance of `issue 32`_, which are the result of an initialization order problem.
+
+.. _issue 32: https://github.com/nedbat/django_coverage_plugin/issues/32
+.. _issue 36: https://github.com/nedbat/django_coverage_plugin/issues/3r
+
 
 v1.4.1 --- 2017-01-25
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -64,10 +64,9 @@ Changes
 v1.4.2 --- 2017-01-30
 ---------------------
 
-Fixes `issue 36`_, and another instance of `issue 32`_, which are the result of an initialization order problem.
+Fixes another instance of `issue 32`_, which was the result of an initialization order problem.
 
 .. _issue 32: https://github.com/nedbat/django_coverage_plugin/issues/32
-.. _issue 36: https://github.com/nedbat/django_coverage_plugin/issues/3r
 
 
 v1.4.1 --- 2017-01-25

--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -54,6 +54,12 @@ def check_debug():
         # into template engines, so we don't need to depend on settings values
         # directly and can look at the resulting configured objects
 
+        # I _think_ this check is all that's needed and the 3 "hasattr" checks
+        # below can be removed, but it's not clear how to verify that
+        from django.apps import apps
+        if not apps.ready:
+            return False
+
         # django.template.backends.django gets loaded lazily, so return false
         # until they've been loaded
         if not hasattr(django.template, "backends"):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Development Status :: 5 - Production/Stable
 
 setup(
     name='django_coverage_plugin',
-    version='1.4.1',
+    version='1.4.2',
     description='Django template coverage.py plugin',
     author='Ned Batchelder',
     author_email='ned@nedbatchelder.com',


### PR DESCRIPTION
Attempt to fix latest django startup order problem specific to DJ 1.10+  Tested against DJ 1.8 through 1.11tip using the "insane integration test" pull request.