### PR TITLE
More fix the Django versions badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ To run the tests::
 .. |versions| image:: https://img.shields.io/pypi/pyversions/django_coverage_plugin.svg
     :target: https://pypi.python.org/pypi/django_coverage_plugin
     :alt: Python versions supported
-.. |djversions| image:: https://img.shields.io/badge/Django-1.8%2C%201.9%2C%201.10%2C%201.11b1.svg
+.. |djversions| image:: https://img.shields.io/badge/Django-1.8%2C%201.9%2C%201.10%2C%201.11b1-44b78b.svg
     :target: https://pypi.python.org/pypi/django_coverage_plugin
     :alt: Django versions supported
 .. |status| image:: https://img.shields.io/pypi/status/django_coverage_plugin.svg


### PR DESCRIPTION
I missed the color the first time, and img.shields.io returns a 404 without it