### PR TITLE
Change install_requires to not require Django

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -78,6 +78,10 @@ def check_debug():
     return True
 
 
+if django.VERSION < (1, 8):
+    raise RuntimeError("Django Coverage Plugin requires Django 1.8 or higher")
+
+
 if django.VERSION >= (1, 9):
     # Since we are grabbing at internal details, we have to adapt as they
     # change over versions.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     url='https://github.com/nedbat/django_coverage_plugin',
     packages=['django_coverage_plugin'],
     install_requires=[
-        'Django >= 1.8',
         'coverage >= 4.0',
         'six >= 1.4.0',
     ],


### PR DESCRIPTION
Addresses #44 
Django being in install_requires makes it hard for a project using django_coverage_plugin and pip-compile to specify their own version of Django.

 - Remove "Django" from setup.py's install_requires 
 - Raise RuntimeError in plugin.py if Django version is lower than 1.8