### PR TITLE
Add logging and new config stuff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,21 @@ The Django template plugin uses some existing settings from your .coveragerc
 file.  The ``source=``, ``include=``, and ``omit=`` options control what
 template files are included in the report.
 
+It also has some optional configuration settings to enable certain debugging flags::
+
+    [django_coverage_plugin]
+    show_startup = True
+    show_tracing = True
+    show_startup = True
+    log_file_path = dj_coverage.log
+
+``show_startup`` will log information during the startup sequence.  This is
+especially useful when debugging settings configurations.
+``show_parsing`` will log information about how a template file is parsed.
+``show_tracing`` will log information about how template code is traced.
+``log_file_path`` is the relative or absolute path to the log file to which log messages
+should be written.  If not specified, log messages will be written to stdout.
+
 
 Caveats
 ~~~~~~~
@@ -55,6 +70,12 @@ plural text, so both are marked as used if the tag is used.
 
 Changes
 ~~~~~~~
+
+v1.5.3 --- 2017-11-28
+----------------------
+
+Exposes debugging configuration settings to .coveragerc. Adds logging to startup.
+Adds option to log to a file for easier issue analysis.
 
 v1.5.2 --- 2017-10-18
 ----------------------

--- a/django_coverage_plugin/__init__.py
+++ b/django_coverage_plugin/__init__.py
@@ -8,4 +8,4 @@ from .plugin import DjangoTemplatePluginException       # noqa
 
 
 def coverage_init(reg, options):
-    reg.add_file_tracer(DjangoTemplatePlugin())
+    reg.add_file_tracer(DjangoTemplatePlugin(options))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Development Status :: 3 - Alpha
 
 setup(
     name='django_coverage_plugin',
-    version='1.5.2',
+    version='1.5.3',
     description='Django template coverage.py plugin',
     author='Ned Batchelder',
     author_email='ned@nedbatchelder.com',


### PR DESCRIPTION
Many of the issues that have been created are configuration and environment related, so the have been difficult to debug and identify.  

This PR exposes the two existing debugging flags `SHOW_TRACING` and `SHOW_PARSING` to the config file options (as per coverage.py documentation).  It also adds two more: `SHOW_STARTUP` and `LOG_FILE`.  

`SHOW_STARTUP` enables extra logging in code that's called during startup, as well as logging the python and django versions.

`LOG_FILE` (called `log_file_path` in the config option) is an optional argument allowing the user to capture all django_coverage_plugin logging to one file, which can be included or requested when tracking down issues.