### PR TITLE
Fix failing tests due to typo in error message

### DIFF
--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -228,7 +228,7 @@ class DjangoPluginTestCase(StdStreamCapturingMixin, TempDirMixin, TestCase):
         stderr = self.stderr()
         self.assertIn(
             "Coverage.py warning: "
-            "Disabling plugin 'django_coverage_plugin.DjangoTemplatePlugin' "
+            "Disabling plug-in 'django_coverage_plugin.DjangoTemplatePlugin' "
             "due to an exception:",
             stderr
         )


### PR DESCRIPTION
[Line 519 in commit 62699a3187 of coverage.py](https://github.com/nedbat/coveragepy/commit/62699a318754c6811622d31cfab195b4dbc3775e#diff-95d8b9a92bced37c487f15f22fbc59e0R519) changed the error message string that local tests match.

