### PR TITLE
Fix #51 - Change token type for Django 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     url='https://github.com/nedbat/django_coverage_plugin',
     packages=['django_coverage_plugin'],
     install_requires=[
+        'enum34;python_version<"3.4"',
         'coverage >= 4.0',
         'six >= 1.4.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@
 envlist =
     py27-django{18,19,110,111,111tip},
     py34-django{18,19,110,111,111tip,20},
-    py35-django{18,19,110,111,111tip,20,tip},
-    py36-django{18,19,110,111,111tip,20,tip},
+    py35-django{18,19,110,111,111tip,20,21,tip},
+    py36-django{111,111tip,20,21,tip},
     check,doc
 
 [testenv]
@@ -29,7 +29,8 @@ deps =
     django110: Django >=1.10, <1.11
     django111: Django >=1.11, <2.0
     django111tip: https://github.com/django/django/archive/stable/1.11.x.tar.gz
-    django20: Django>=2.0b1,<2.1
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1rc1,<2.2
     djangotip: https://github.com/django/django/archive/master.tar.gz
 
 commands =


### PR DESCRIPTION
Hi,
This PR is similar to #52 , but takes a slightly different approach. Instead of retrofitting the new Django feature to avoid changing current code in this repo, this PR opts to add code so that previous versions of Django now operate in the new fashion.

Advantages:
- built to work with future versions of Django
-  in the future, you can simply delete code to remove technical debt

Disadvantages:
- adds `enum34` as a conditional dependency for Python<3.4
- adds more code than the other PR
- slightly slower than the other PR, as an extra function is called to enable compatibility between Django versions

This PR also takes the liberty of:
- sorting imports with `isort`
- using `_` to denote an unused variable
- remove import compatibility for `VerbatimNode` check for Django<1.5 (as only Django>=1.8 is supported)
- remove Python 3.6 tests for Django<1.11, as Python 3.6 is not officially supported in those versions

**NB**: tests run in new Tox environments will fail until #54 is merged.

I realize some of these decisions are a bit controversial, and won't mind at all if you opt to close this. I figured I'd give you an option, though!

Thanks again for your time and for the package.