### PR TITLE
Another take on adding support for Django 2.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,9 @@
 envlist =
     py27-django{18,19,110,111,111tip},
     py34-django{18,19,110,111,111tip,20},
-    py35-django{18,19,110,111,111tip,20,tip},
-    py36-django{18,19,110,111,111tip,20,tip},
+    py35-django{18,19,110,111,111tip,20,21,tip},
+    py36-django{18,19,110,111,111tip,20,21,tip},
+    py37-django{20,21,tip},
     check,doc
 
 [testenv]
@@ -30,6 +31,7 @@ deps =
     django111: Django >=1.11, <2.0
     django111tip: https://github.com/django/django/archive/stable/1.11.x.tar.gz
     django20: Django>=2.0b1,<2.1
+    django21: Django>=2.1, <2.2
     djangotip: https://github.com/django/django/archive/master.tar.gz
 
 commands =


### PR DESCRIPTION
This is the solution I came up with, which turned out to be similar to https://github.com/nedbat/django_coverage_plugin/pull/56, except it does not add any additional dependencies to `django-coverage-plugin`.

I think it strikes a good balance between simplicity and facilitating its own removal later.

@jambonrose what do you think about this approach?

@PamelaM @nedbat any chance we can get either one merged soon? 