### PR TITLE
Fix template tags missing when the tags module is imported during test collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+dist: xenial
 python:
   - "2.7"
   - "3.4"

--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -75,6 +75,8 @@ def check_debug():
         return False
     if not hasattr(django.template.backends.django, "DjangoTemplates"):
         raise DjangoTemplatePluginException("Can't use non-Django templates.")
+    if not django.template.engines._engines:
+        return False
 
     for engine in django.template.engines.all():
         if not isinstance(engine, django.template.backends.django.DjangoTemplates):

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,9 @@
 envlist =
     py27-django{18,19,110,111,111tip},
     py34-django{18,19,110,111,111tip,20},
-    py35-django{18,19,110,111,111tip,20,21,tip},
-    py36-django{18,19,110,111,111tip,20,21,tip},
-    py37-django{20,21,tip},
+    py35-django{18,19,110,111,111tip,20,21,22},
+    py36-django{18,19,110,111,111tip,20,21,22,tip},
+    py37-django{20,21,22,tip},
     check,pkgcheck,doc
 
 [testenv]
@@ -31,6 +31,7 @@ deps =
     django111tip: https://github.com/django/django/archive/stable/1.11.x.tar.gz
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<3.0
     djangotip: https://github.com/django/django/archive/master.tar.gz
 
 commands =


### PR DESCRIPTION
I'm hitting this error

```
django.template.exceptions.TemplateSyntaxError: 'l10n' is not a registered tag library.
```

when trying to load Django's `l10n` library in a template while using pytest and django_coverage_plugin. Tests pass when the plugin is not used. This started happening after adding `from django.templatetags.l10n import localize` to a test module.

This happens in Python 3.6 with Django 1.11.

From my investigation of the issue, it's triggered in the following way:

* pytest's test collector imports the test module
* The test module imports the `l10n` template tag
* The tracer kicks in because [templatetags modules are included since `'template'` is a prefix of `'templatetags'`](https://github.com/nedbat/django_coverage_plugin/blob/0072737c0ea5a1ca6b9f046af4947de191f13804/django_coverage_plugin/plugin.py#L169) and this causes [check_debug() to be run](https://github.com/nedbat/django_coverage_plugin/blob/0072737c0ea5a1ca6b9f046af4947de191f13804/django_coverage_plugin/plugin.py#L173) at a time when `django.template.engines` hasn't imported the engines yet.
* [This line](https://github.com/nedbat/django_coverage_plugin/blob/0072737c0ea5a1ca6b9f046af4947de191f13804/django_coverage_plugin/plugin.py#L79) triggers loading of the engines through https://github.com/django/django/blob/1.11.21/django/template/utils.py#L80
* Because we're still in the middle of importing `l10n`, [this import works](https://github.com/django/django/blob/1.11.21/django/template/backends/django.py#L126) but [the module does not _yet_ have a `register` attribute](https://github.com/django/django/blob/1.11.21/django/template/backends/django.py#L133)
* Thus Django considers `l10n` not to be a template tags module and does not register it and considers the template engine to be fully loaded.

I believe the root issue here is that `check_debug()` is trying to import template engines too early and that the ` if not apps.ready:` check is not enough. Unfortunately I couldn't find any other way to detect that the engines have been loaded other than by looking at the internal variable `_engines`.

Can confirm that this fixes https://github.com/nedbat/django_coverage_plugin/issues/63 using the [test case attached there](https://github.com/TauPan/pytest-django-xdist-cov-bug).

Wasn't able to add a test to this PR as the bug depends on pytest's collector.