### PR TITLE
Work with coverage 4.x or 5.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Supported Python versions: 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
 
 Supported Django versions: 1.8, 1.11, 2.0, 2.1, 2.2 and 3.0.
 
-Supported coverage.py version 4.x . Support for version 5 is on the way!
+Supported coverage.py version 4.x or 5.x.
 
 The plugin is pip installable::
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url='https://github.com/nedbat/django_coverage_plugin',
     packages=['django_coverage_plugin'],
     install_requires=[
-        'coverage >= 4.0 , < 5',
+        'coverage',
         'six >= 1.4.0',
     ],
     license='Apache 2.0',

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -136,7 +136,11 @@ class DjangoPluginTestCase(StdStreamCapturingMixin, TempDirMixin, TestCase):
         self.cov.stop()
         self.cov.save()
         # Warning! Accessing secret internals!
-        for pl in self.cov.plugins:
+        if hasattr(self.cov, 'plugins'):
+            plugins = self.cov.plugins
+        else:
+            plugins = self.cov._plugins
+        for pl in plugins:
             if isinstance(pl, DjangoTemplatePlugin):
                 if not pl._coverage_enabled:
                     raise PluginDisabled()
@@ -174,7 +178,7 @@ class DjangoPluginTestCase(StdStreamCapturingMixin, TempDirMixin, TestCase):
 
     def measured_files(self):
         """Get the list of measured files, in relative form."""
-        return [os.path.relpath(f) for f in self.cov.data.measured_files()]
+        return [os.path.relpath(f) for f in self.cov.get_data().measured_files()]
 
     def assert_analysis(self, executable, missing=None, name=None):
         """Assert that the analysis for `name` is right."""


### PR DESCRIPTION
@jambonrose This makes it work for both, though it's not nice.  I wondered about mocking the creation of the plugins to track which had been made during the test, but I didn't quickly see a way to do that.

Also, I don't know if we should support 4.x and 5.x (which would double the already bulky list of tox environments), or just move to 5?