### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
         exclude:
           # Windows 2.7 doesn't work because Microsoft removed stuff we needed.
           - os: windows-latest

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Software Development :: Quality Assurance

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ envlist =
     py37-django{22,32},
     py38-django{22,32,tip},
     py39-django{22,32,tip},
+    py310-django{32,tip},
     check,pkgcheck,doc
 
 [testenv]
@@ -75,3 +76,4 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310


### PR DESCRIPTION
- adds 3.10 to GH workflow testing matrix and tox.ini, with [passing tests](https://github.com/joshuadavidthomas/django_coverage_plugin/actions)
- adds the needed trove classifers

I wasn't sure whether to change the supported Python version in the README as well.