### PR TITLE
Add test with non-unicode text file

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -145,7 +145,7 @@ def read_template_source(filename):
             charset = 'utf-8'
         else:
             charset = settings.FILE_CHARSET
-        text = f.read().decode(charset)
+        text = f.read().decode(charset, errors='backslashreplace')
 
     return text
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -262,3 +262,11 @@ class BranchTest(DjangoPluginTestCase):
             )
         self.assertEqual(text, 'Hello\nWorld\n\nGoodbye')
         self.assert_analysis([1, 2, 3, 4])
+
+
+class TestNonUTF8StaticFile(DjangoPluginTestCase):
+    def test_non_utf8_static_file(self):
+        # Non-template file containing a word encoded in CP-1252
+        self.make_file("static/german.txt", bytes=b"sh\xf6n")
+        self.run_django_coverage(text='Hello')
+        self.assertEqual(self.get_html_report('../static/german.txt'), 0)


### PR DESCRIPTION
Added a test that demonstrates the behavior reported in issue #78

Not sure how to fix this, so I'll keep this PR as a draft. Any guidance on how to "fix" this would be much appreciated.