### PR TITLE
Use the lineno attribute of TextNode.token if TextNode.position is unavailable

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -112,6 +112,14 @@ if django.VERSION >= (1, 9):
         except (KeyError, AttributeError):
             return None
 
+    def lines_for_node(n):
+        try:
+            startLine = n.token.lineno
+            count = len(n.s.splitlines(True)) if isinstance(n, TextNode) else 0
+            return startLine, startLine + count
+        except AttributeError:
+            return None
+
     def position_for_node(node):
         try:
             return node.token.position
@@ -126,6 +134,9 @@ else:
             return frame.f_locals["self"].source[0].name
         except (KeyError, AttributeError, IndexError):
             return None
+
+    def lines_for_node(node):
+        return None
 
     def position_for_node(node):
         return node.source[1]
@@ -249,7 +260,8 @@ class DjangoTemplatePlugin(
 
         position = position_for_node(render_self)
         if position is None:
-            return -1, -1
+            lines = lines_for_node(render_self)
+            return lines if lines else (-1, -1)
 
         if SHOW_TRACING:
             print("{!r}: {}".format(render_self, position))


### PR DESCRIPTION
This fixed an issue I had in one of my files. I have no idea whether the TextNode was lacking a position because of a bug within Django or in my code, or if this was to be expected and Django_Coverage_Plugin needs to handle this.

I don't have a test case that I can publicly share, but I can say that without my change, it wasn't properly seeing that the file was being used, and with this change, it worked fine.