### PR TITLE
fix: add support for Django 4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ A `coverage.py`_ plugin to measure test coverage of Django templates.
 
 Supported Python versions: 2.7, and 3.6 through 3.10.
 
-Supported Django versions: 1.8, 1.11, 2.x and 3.x.
+Supported Django versions: 1.8, 1.11, 2.x, 3.x and 4.x.
 
 Supported coverage.py versions: 4.x or higher.
 
@@ -129,6 +129,11 @@ To run the tests::
 
 History
 ~~~~~~~
+
+Unreleased
+----------
+
+Add support for Django 4.0
 
 v2.0.2 — 2021-11-11
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ Framework :: Django :: 1.8
 Framework :: Django :: 1.11
 Framework :: Django :: 2.2
 Framework :: Django :: 3.2
+Framework :: Django :: 4.0
 """
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ envlist =
     py27-django{18,111},
     py36-django{18,111,22,32},
     py37-django{22,32},
-    py38-django{22,32,tip},
-    py39-django{22,32,tip},
-    py310-django{32,tip},
+    py38-django{22,32,40,tip},
+    py39-django{22,32,40,tip},
+    py310-django{32,40,tip},
     check,pkgcheck,doc
 
 [testenv]
@@ -30,6 +30,7 @@ deps =
     django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
+    django40: Django>=4.0,<4.1
     djangotip: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
- Add Django 4.0 to the test matrix
- Update readme to mention support for 4.x
- Update Trove classifiers