### PR TITLE
test: fix build against djangotip

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -365,7 +365,7 @@ class FileReporter(coverage.plugin.FileReporter):
                         continue
 
                 if extends and not inblock:
-                    # In an inheriting tempalte, ignore all tags outside of
+                    # In an inheriting template, ignore all tags outside of
                     # blocks.
                     continue
 

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -45,6 +45,9 @@ def test_settings():
                 'DIRS': ['templates'],      # where the tests put things.
                 'OPTIONS': {
                     'debug': True,
+                    'loaders': [
+                        'django.template.loaders.filesystem.Loader',
+                    ]
                 },
             },
         ],


### PR DESCRIPTION
Django recently enabled the cached template loader by default in development. This was added in https://github.com/django/django/pull/15586 (commit https://github.com/django/django/commit/bf7c51a5f4da5f00b46923545ea6657ba9556bf6).

As a result, some tests started failing when the whole test suite was run, but not when they were run individually.

We can fix this by setting the template loaders in our test settings.