### PR TITLE
Add Django 4.1 to tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ envlist =
     py27-django{18,111},
     py36-django{18,111,22,32},
     py37-django{22,32},
-    py38-django{22,32,40,tip},
-    py39-django{22,32,40,tip},
-    py310-django{32,40,tip},
+    py38-django{22,32,40,41,tip},
+    py39-django{22,32,40,41,tip},
+    py310-django{32,40,41,tip},
     check,pkgcheck,doc
 
 [testenv]
@@ -31,6 +31,7 @@ deps =
     django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangotip: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
Either this PR will need to be rebased after #90 is merged to bring in Python 3.11, or #90 will need to be rebased to bring in Django 4.1.
