### PR TITLE
Add a configuration option to allow block tags to be excluded by regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,15 +91,17 @@ extensions if you like::
     [django_coverage_plugin]
     template_extensions = html, txt, tex, email
 
-If you use ``pyproject.toml`` for tool configuration use::
+To exclude specific individual lines in a template, use the usual
+``# pragma: no cover`` notation inline. Template tags can also be excluded using regexes to 
+match the block content; for example, to exclude a custom template tag
+``{% my_tag ... %}``, use::
 
-    [tool.coverage.run]
-    plugins = [
-        'django_coverage_plugin',
-    ]
+    [run]
+    plugins = django_coverage_plugin
 
-    [tool.coverage.django_coverage_plugin]
-    template_extensions = 'html, txt, tex, email'
+    [django_coverage_plugin]
+    exclude_blocks = ["my_tag.+"]
+
 
 Caveats
 ~~~~~~~

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -264,3 +264,30 @@ class BranchTest(DjangoPluginTestCase):
             )
         self.assertEqual(text, 'Hello\nWorld\n\nGoodbye')
         self.assert_analysis([1, 2, 3, 4])
+
+
+class ExcludeTest(DjangoPluginTestCase):
+    """Tests of excluding block tokens by regex."""
+
+    def test_exclude_block(self):
+        self.make_template("""\
+            First
+            {% with foo='bar' %}
+                {{ foo }}
+            {% endwith %}
+            Last
+            """)
+        text = self.run_django_coverage()
+        self.assertEqual(text, "First\n\n    bar\n\nLast\n")
+        self.assert_analysis([1, 2, 3, 5])
+
+        self.make_file(".coveragerc", """\
+            [run]
+            plugins = django_coverage_plugin
+            [django_coverage_plugin]
+            exclude_blocks = [".+foo.+"]
+            """)
+        
+        text = self.run_django_coverage()
+        self.assertEqual(text, "First\n\n    bar\n\nLast\n")
+        self.assert_analysis([1, 3, 5])


### PR DESCRIPTION
Thanks for this plugin, which did almost exactly what we needed, apart from one issue, which this PR is an attempt to address.  

The issue we had was that our project is using [slippers](https://github.com/mixxorz/slippers), which means we have component tags in our templates with start/end block tags that don't follow the usual django convention for the end tag (`{% end<...> %}`). Instead they look something like 
```
{% #card %}
...
{% /card %}
```
This means that any component end tag on its own line gets marked as uncovered.

This PR adds a config option `exclude_blocks` which takes a list of regexes, similar to `exclude_also` in the main coverage config, and allow us to specify patterns to match and exclude the content of block tags. With the following pyproject.toml config, we can now exclude any block tags that start with "/" (ie slippers component end tags).
```
[tool.coverage.django_coverage_plugin]
template_extensions = "html"
exclude_blocks = [
    "\\/\\w+"
]
```

I didn't add a similar exclude option for text tags because there's additional complexity there since a text tag can span multiple lines (and I haven't seen issues that suggest it's a feature anyone needs yet)