### PR TITLE
Allow ignoring script tags.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,18 @@ If you use ``pyproject.toml`` for tool configuration use::
     [tool.coverage.django_coverage_plugin]
     template_extensions = 'html, txt, tex, email'
 
+By default, <script> tags will be marked as covered if they were rendered. If you are collecting
+in-browser coverage data, you can instruct the plugin not to count the content of the script tags
+as covered::
+
+    [run]
+    plugins = django_coverage_plugin
+
+    [django_coverage_plugin]
+    ignore_script_tags = true
+
+
+
 Caveats
 ~~~~~~~
 

--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -5,6 +5,7 @@
 
 import os.path
 import re
+import html.parser
 
 try:
     from coverage.exceptions import NoSource
@@ -158,6 +159,8 @@ class DjangoTemplatePlugin(
 
         self.source_map = {}
 
+        self.ignore_script_tags = options.get('ignore_script_tags', False)
+
     # --- CoveragePlugin methods
 
     def sys_info(self):
@@ -184,7 +187,7 @@ class DjangoTemplatePlugin(
         return None
 
     def file_reporter(self, filename):
-        return FileReporter(filename)
+        return FileReporter(filename, ignore_script_tags=self.ignore_script_tags)
 
     def find_executable_files(self, src_dir):
         # We're only interested in files that look like reasonable HTML
@@ -291,12 +294,37 @@ class DjangoTemplatePlugin(
         return self.source_map[filename]
 
 
+class ScriptParser(html.parser.HTMLParser):
+    # We never have nested script tags, so we are all good.
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.script_lines = []
+        self.in_script = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'script':
+            self.in_script = True
+
+    def handle_endtag(self, tag):
+        if tag == 'script':
+            self.in_script = False
+
+    def handle_data(self, data):
+        if self.in_script:
+            start_line = self.getpos()[0]
+            self.script_lines.extend([
+                line + start_line + 1 for line in range(data.rstrip().count('\n'))
+            ])
+
+
 class FileReporter(coverage.plugin.FileReporter):
-    def __init__(self, filename):
+    def __init__(self, filename, *, ignore_script_tags=False):
         super().__init__(filename)
         # TODO: html filenames are absolute.
 
         self._source = None
+        self.ignore_script_tags = ignore_script_tags
 
     def source(self):
         if self._source is None:
@@ -305,6 +333,16 @@ class FileReporter(coverage.plugin.FileReporter):
             except (OSError, UnicodeError) as exc:
                 raise NoSource(f"Couldn't read {self.filename}: {exc}")
         return self._source
+
+    def translate_lines(self, lines):
+        if self.ignore_script_tags:
+            # Initially, we'll only support "simple" script contents, ie,
+            # they may not have any django template directives within them.
+            parser = ScriptParser()
+            parser.feed(self.source())
+            return {line for line in lines if line not in parser.script_lines}
+
+        return super().translate_lines(lines)
 
     def lines(self):
         source_lines = set()


### PR DESCRIPTION
This allows setting a flag to unconditionally mark the contents of <script> tags as uncovered.

This means that in-browser coverage collection can be used to truly measure if these lines are executed.