### PR TITLE
Include Django 5.0 & 5.1 in test matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ Framework :: Django :: 1.11
 Framework :: Django :: 2.2
 Framework :: Django :: 3.2
 Framework :: Django :: 4.2
+Framework :: Django :: 5.0
+Framework :: Django :: 5.1
 """
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 envlist =
-    py38-django{22,32,42}-cov{6,7,tip},
+    py38-django{22,32,42}-cov{6,7,cov7py38},
     py39-django{22,32,42}-cov{6,7,tip},
     py310-django{32,42,50,51,tip}-cov{6,7,tip},
     py311-django{42,50,51,tip}-cov{6,7,tip},
@@ -24,6 +24,7 @@ envlist =
 [testenv]
 deps =
     cov6: coverage>=6.0,<7.0
+    cov7py38: coverage>=7.0,<7.6.2
     cov7: coverage>=7.0,<8.0
     covtip: git+https://github.com/nedbat/coveragepy.git
     django22: Django>=2.2,<3.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,9 @@
 envlist =
     py38-django{22,32,42}-cov{6,7,tip},
     py39-django{22,32,42}-cov{6,7,tip},
-    py310-django{32,42,tip}-cov{6,7,tip},
-    py311-django{42,tip}-cov{6,7,tip},
-    py312-django{tip}-cov{7,tip},
+    py310-django{32,42,50,51,tip}-cov{6,7,tip},
+    py311-django{42,50,51,tip}-cov{6,7,tip},
+    py312-django{42,50,51,tip}-cov{7,tip},
     check,pkgcheck,doc
 
 [testenv]
@@ -29,6 +29,8 @@ deps =
     django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
     django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
     djangotip: git+https://github.com/django/django.git
     pytest
     unittest-mixins==1.6


### PR DESCRIPTION
This updates the Tox test matrix to include Django 5.0 & 5.1 

Dropping support for Python 3.8 and older Django version can be done in separated PR. 