### PR TITLE
Fix #70: don't measure comment contents in inheriting templates

### DIFF
--- a/django_coverage_plugin/plugin.py
+++ b/django_coverage_plugin/plugin.py
@@ -309,13 +309,16 @@ class FileReporter(coverage.plugin.FileReporter):
                     if extends:
                         continue
 
+                if token.contents == "comment":
+                    # Set this before the extends-skip below: in an inheriting
+                    # template a comment outside the blocks must still suppress
+                    # measurement of its contents (issue #70).
+                    comment = True
+
                 if extends and not inblock:
                     # In an inheriting template, ignore all tags outside of
                     # blocks.
                     continue
-
-                if token.contents == "comment":
-                    comment = True
                 if token.contents.startswith("end"):
                     continue
                 elif token.contents in ("else", "empty"):

--- a/tests/test_extends.py
+++ b/tests/test_extends.py
@@ -106,6 +106,31 @@ class BlockTest(DjangoPluginTestCase):
         self.assert_analysis([1, 2, 3], name="base.html")
         self.assert_analysis([1, 4, 8], [8], name="specific.html")
 
+    def test_inheriting_with_comment_outside_blocks(self):
+        # https://github.com/coveragepy/django_coverage_plugin/issues/70
+        # A {% comment %} outside the blocks of an inheriting template was
+        # skipped before the comment flag was set, so {{ vars }} inside the
+        # comment were measured as executable lines that can never run.
+        self.make_template(name="base.html", text="""\
+            Hello
+            {% block second_line %}second{% endblock %}
+            """)
+
+        self.make_template(name="specific.html", text="""\
+            {% extends "base.html" %}
+            {% comment %}
+                {{ this.line.was.reported.missing }}
+            {% endcomment %}
+            {% block second_line %}
+            SECOND
+            {% endblock %}
+            """)
+
+        text = self.run_django_coverage(name="specific.html")
+        self.assertEqual(text, "Hello\n\nSECOND\n\n")
+        self.assert_analysis([1, 2], name="base.html")
+        self.assert_analysis([1, 6], name="specific.html")
+
     def test_empty_parent_block_on_new_line_when_extended(self):
         """
         When a block is empty and extended, endblock should not appear


### PR DESCRIPTION
Fixes the `{% comment %}` part of #70 — for comments in inheriting templates it is not a missing "ignore" feature, it is a measurement bug.

In a template that `{% extends %}` another, a `{% comment %}` opener placed outside of any `{% block %}` is skipped by the `extends and not inblock` continue before `comment = True` is set. Variable tokens inside the comment are then recorded as executable lines and reported as missing forever — they can never run. (Plain text inside the comment happens to be saved by the text branch's own extends-guard, which is why the symptom only shows when the comment contains `{{ vars }}` or tags.)

Minimal repro:

```django
{% extends "base.html" %}
{% comment %}
    {{ this.line.is.reported.missing }}
{% endcomment %}
{% block content %}covered{% endblock %}
```

The fix sets the comment flag before the extends-skip, mirroring how `{% endcomment %}` is already handled earlier in the loop. Includes a regression test; the full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
